### PR TITLE
Add bybit email column on report matches

### DIFF
--- a/src/app/bb/report/[id]/page.tsx
+++ b/src/app/bb/report/[id]/page.tsx
@@ -749,6 +749,7 @@ export default function ReportDetailPage() {
                 >
                   Bybit orderNo {renderSortIndicator("matches", "bybitOrderNo")}
                 </TableColumn>
+                <TableColumn>Bybit Email</TableColumn>
                 <TableColumn
                   onClick={() => handleSort("matches", "idexExternalId")}
                   style={{ cursor: "pointer" }}
@@ -809,6 +810,9 @@ export default function ReportDetailPage() {
                         .format("DD.MM.YY HH:mm")}
                     </TableCell>
                     <TableCell>{match.bybitTransaction?.orderNo}</TableCell>
+                    <TableCell>
+                      {match.bybitTransaction?.cabinet?.bybitEmail}
+                    </TableCell>
                     <TableCell>{match.idexTransaction?.externalId}</TableCell>
                     <TableCell>
                       {formatAmount(match.bybitTransaction?.totalPrice)}


### PR DESCRIPTION
## Summary
- show bybit email for each matched transaction
- include cabinet email in API response so frontend can display it

## Testing
- `npm run check` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f4699e5648320a7007753230b39c9